### PR TITLE
Added missing call to super in application controller init function

### DIFF
--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -5,6 +5,7 @@ export default Ember.Controller.extend({
   iceServers: null,
 
   init () {
+    this._super(...arguments);
     if (window.Realtime) {
       this.connectRealtime();
     } else {


### PR DESCRIPTION
One of the controllers was missing a call to this._super causing an ember assertion to fail when loading the app in a browser.