### PR TITLE
no-jira use creds to push tag and prep next version to github

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,14 +28,19 @@ webappPipeline {
         ]
     }
 
-    shouldTagOnRelease = { true }
+    shouldTagOnRelease = { false }
 
     postReleaseStep = {
-        sh("""
-            # patch to prep for the next version
-            npm version patch --no-git-tag-version
-            git commit -am "Prep next version"
-            git push origin HEAD:master --tags
-        """)
+      sshagent(credentials: [constants.credentials.github.inin_dev_evangelists]) {
+          sh("""
+              # tag the version
+              git tag v${version}
+              git push origin --tags
+              # patch to prep for the next version
+              npm version patch --no-git-tag-version
+              git commit -am "Prep next version"
+              git push origin HEAD:master --tags
+          """)
+      }
     }
 }


### PR DESCRIPTION
The `constants.credentials.github.inin_dev_evangelists` credentials are using to clone the repo, but are not used for anything else after that. We need to explicitly use them when pushing tags and version prep to github. Haven't tested this yet (since it is a `postReleaseStep`). Should work since I borrowed from other projects that do have this working. 